### PR TITLE
Fix extra page header memory address

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1226,7 +1226,8 @@ static void *gc_alloc_page_memory( int size ) {
 			ptr = mmap(base_addr,size+EXTRA_SIZE,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0);
 			int offset = (int)((int_val)ptr) & (GC_PAGE_SIZE-1);
 			void *aligned = (char*)ptr + (GC_PAGE_SIZE - offset);
-			pextra *inf = (pextra*)(offset > (EXTRA_SIZE>>1) ? ((char*)ptr + EXTRA_SIZE - sizeof(pextra)) : (char*)ptr);
+			pextra *inf = (pextra*)( (char*)ptr + size + EXTRA_SIZE - sizeof(pextra));
+
 			inf->page_ptr = aligned;
 			inf->base_ptr = ptr;
 			inf->next = extra_pages;


### PR DESCRIPTION
With the current code the `pextra *` pointer could be in `[page_ptr, page_ptr+size]` interval, which is incorrect.

There probably was a missing `+ size`  in `(char*)ptr + EXTRA_SIZE - sizeof(pextra)`.

But as we have an extra size at the end :
`#define EXTRA_SIZE (GC_PAGE_SIZE + (4<<10))`) 

Let's store that extra header always at the end.